### PR TITLE
[refactor] 테이블 이름 변경(chat -> chat_session, chat_session -> conversation)

### DIFF
--- a/domain/chat/chat_crud.py
+++ b/domain/chat/chat_crud.py
@@ -1,35 +1,35 @@
-from models import Chat, ChatSession, Bot
+from models import ChatSession, Conversation, Bot
 from sqlalchemy.orm import Session
 from domain.chat import chat_schema
 
 
-def get_chat_histories(db: Session, user_id: int) -> list[Chat]:
+def get_chat_session_histories(db: Session, user_id: int) -> list[ChatSession]:
     # 쿼리 작성 및 실행
-    chats = db.query(Chat).filter(Chat.user_id == user_id).order_by(Chat.updated_at.desc()).all()
-    return chats
-
-def get_chat_sessions(db: Session, chat_id: int):
-    chat_sessions = db.query(ChatSession).filter(ChatSession.chat_id == chat_id).order_by(ChatSession.id.asc()).all()
+    chat_sessions = db.query(ChatSession).filter(ChatSession.user_id == user_id).order_by(ChatSession.updated_at.desc()).all()
     return chat_sessions
 
-def get_chat(db: Session, chat_id: int):
-    chat = db.query(Chat).filter(Chat.id == chat_id).first()
-    return chat
+def get_conversations(db: Session, chat_session_id: int):
+    conversations = db.query(Conversation).filter(Conversation.chat_session_id == chat_session_id).order_by(Conversation.id.asc()).all()
+    return conversations
 
-def create_chat_session(db: Session, _chat_session_create: chat_schema.ChatSessionCreate):
-    chat_session = ChatSession(chat_id=_chat_session_create.chat_id, 
-                               sender=_chat_session_create.sender, 
-                               message=_chat_session_create.message, 
-                               sender_id = _chat_session_create.sender_id)
+def get_chat_session(db: Session, session_id: int):
+    chat_session = db.query(ChatSession).filter(ChatSession.id == session_id).first()
+    return chat_session
+
+def create_conversation(db: Session, conversation_create: chat_schema.ConversationCreate):
+    chat_session = Conversation(chat_session_id=conversation_create.chat_session_id, 
+                               sender=conversation_create.sender, 
+                               message=conversation_create.message, 
+                               sender_id = conversation_create.sender_id)
     db.add(chat_session)
     db.commit()
 
-def create_chat(db: Session, _chat_create: chat_schema.ChatCreate):
-    chat = Chat(user_id = _chat_create.user_id,
-                title = _chat_create.title)
-    db.add(chat)
+def create_chat_session(db: Session, chat_session_create: chat_schema.ChatSessionCreate):
+    chat_session = ChatSession(user_id = chat_session_create.user_id,
+                title = chat_session_create.title)
+    db.add(chat_session)
     db.commit()
-    return chat
+    return chat_session
 
 def get_bot(db: Session, bot_id: int):
     bot = db.query(Bot).filter(Bot.id == bot_id).first()

--- a/domain/chat/chat_schema.py
+++ b/domain/chat/chat_schema.py
@@ -1,32 +1,29 @@
 from pydantic import BaseModel
 from typing import Optional
 
-class ChatCreate(BaseModel):
+class ChatSessionCreate(BaseModel):
     user_id: int
-    title: Optional[str] = "임시 chat"
+    title: Optional[str] = "New chat"
 
 
-class ChatCreateRequest(BaseModel):
+class ChatSessionCreateRequest(BaseModel):
     title: str
 
 
-class Chat(BaseModel):
-  pass
-
-class ChatSessionCreate(BaseModel):
-    chat_id: int
+class ConversationCreate(BaseModel):
+    chat_session_id: int
     sender: str
     message: str
     sender_id: int
 
 class UserChatSessionCreateRequest(BaseModel):
-    chat_id: int
+    chat_session_id: int
     sender: str
     message: str
    
 
 class GenerateAnswerRequest(BaseModel):
-   chat_id: int
+   chat_session_id: int
    bot_id: int
    question: str
    context: Optional[list]

--- a/frontend/src/routes/Home.svelte
+++ b/frontend/src/routes/Home.svelte
@@ -7,7 +7,7 @@
   $: chatTitles, sessionMessages
   let activeMessages = []
   let userMessage = '';
-  let activeChatId = -1;
+  let activeChatSessionId = -1;
   let isSidebarVisible = true;
   let newChatTitle = '';
   let isNewChatModalOpen = false;
@@ -26,7 +26,7 @@
     if (userMessage.trim()) {
       let url = '/api/chat/session'
       let params = {
-        chat_id: activeChatId,
+        chat_session_id: activeChatSessionId,
         sender: 'user',
         message: userMessage
       }
@@ -59,7 +59,7 @@
             'Accept': 'text/event-stream'
         }
     let params = {
-            chat_id: activeChatId,
+            chat_session_id: activeChatSessionId,
             bot_id: 1,
             question: userMessage,
             context: $sessionMessages.messages
@@ -165,7 +165,7 @@
     )
   }
   function selectChat(id) {
-    activeChatId = id
+    activeChatSessionId = id
     getSessionMessages(id)
   }
   function toggleSidebar() {
@@ -363,7 +363,7 @@
           {#each $chatTitles as chatTitle}
             <button
               on:click={() => selectChat(chatTitle.id)}
-              class:active={chatTitle.id === activeChatId}
+              class:active={chatTitle.id === activeChatSessionId}
             >
               {chatTitle.name}
             </button>
@@ -424,7 +424,7 @@
     </div>
     <!-- TODO: Active Chat ID 가 -1일 경우 비어있는 chatting으로 화면 rendering(store 변수 때문에 계속 남아있음) -->
     <div class="messages">
-      {#if activeChatId !== -1}
+      {#if activeChatSessionId !== -1}
         {#each $sessionMessages.messages as message }
           <div class="message {message.sender}">
             {message.text}

--- a/models.py
+++ b/models.py
@@ -32,34 +32,34 @@ class SocialAccount(Base):
     provider = Column(String, nullable = False)
     provider_user_id = Column(String, unique=True, nullable = False)
 
-class Chat(Base):
-    __tablename__ = "chat"
+class ChatSession(Base):
+    __tablename__ = "chat_session"
     id = Column(Integer, primary_key = True, index= True)
     user_id = Column(Integer, ForeignKey("user.id"))
     title = Column(String, nullable = True)
     created_at = Column(DateTime, default=lambda: datetime.now(KST), nullable=False)
     updated_at = Column(DateTime, default=lambda: datetime.now(KST), onupdate=lambda: datetime.now(KST), nullable=False)
-    user = relationship("User", backref="chats")
+    user = relationship("User", backref="chat_sessions")
 
-class ChatSessionSenderType(enum.Enum):
+class ConversationSenderType(enum.Enum):
     user = "user"
     bot = "bot"
 
-class ChatSession(Base):
-    __tablename__ = "chat_session"
+class Conversation(Base):
+    __tablename__ = "conversation"
     id = Column(Integer, primary_key=True, index=True)
-    chat_id = Column(Integer, ForeignKey("chat.id"), nullable=False) 
-    sender = Column(Enum(ChatSessionSenderType), nullable=False)  
+    chat_session_id = Column(Integer, ForeignKey("chat_session.id"), nullable=False) 
+    sender = Column(Enum(ConversationSenderType), nullable=False)  
     sender_id = Column(Integer, nullable=False, default = -1)
     message = Column(String, nullable=True)
     created_at = Column(DateTime, default=lambda: datetime.now(KST), nullable=False)
     updated_at = Column(DateTime, default=lambda: datetime.now(KST), onupdate=lambda: datetime.now(KST), nullable=False)
-    chat = relationship("Chat", backref="sessions")
+    chat_session = relationship("ChatSession", backref="conversations")
     def get_sender(self):
-        if self.sender == ChatSessionSenderType.user:
-            return self.session.query(User).get(self.sender_id)
-        elif self.sender == ChatSessionSenderType.bot:
-            return self.session.query(Bot).get(self.sender_id)
+        if self.sender == ConversationSenderType.user:
+            return self.conversation.query(User).get(self.sender_id)
+        elif self.sender == ConversationSenderType.bot:
+            return self.conversation.query(Bot).get(self.sender_id)
     
 class Bot(Base):
     __tablename__ = "bot"


### PR DESCRIPTION
langchain에서 대화방의 의미를 session으로 사용하고

개별 message의 의미를 conversation으로 사용하여 혼란을 방지하기 위해 사전 작업으로 테이블 이름 및 변수명 모두 변경

여기서 session은 다양한 의미로 해석될 수 있기 때문에 명시적으로 chat_session으로 작업