### PR TITLE
[fix] session store 변수(dict) 초기화 문제

### DIFF
--- a/domain/chat/chat_utils.py
+++ b/domain/chat/chat_utils.py
@@ -24,7 +24,7 @@ class InMemoryHistory(BaseChatMessageHistory, BaseModel):
 
 chat_session_store = {}
 
-def get_chat_session_history_from_dict(chat_session_id: str) -> BaseChatMessageHistory:
+def get_chat_session_history_from_dict(chat_session_id: int) -> BaseChatMessageHistory:
     if chat_session_id not in chat_session_store:
         chat_session_store[chat_session_id] = InMemoryChatMessageHistory()
     return chat_session_store[chat_session_id]
@@ -32,12 +32,13 @@ def get_chat_session_history_from_dict(chat_session_id: str) -> BaseChatMessageH
 
 def get_chat_session_history_from_db(chat_session_store: dict, db: Session, chat_session_id: int):
     conversations = chat_crud.get_conversations(db, chat_session_id = chat_session_id)
+    get_chat_session_history_from_dict(chat_session_id)
     if conversations:
         for conversation in conversations:
             if conversation.sender.value == "user":
-                chat_session_store.add_message(HumanMessage(content = conversation.message))
+                chat_session_store[chat_session_id].add_message(HumanMessage(content = conversation.message))
             elif conversation.sender.value == "bot":
-                chat_session_store.add_message(AIMessage(content=conversation.message))
+                chat_session_store[chat_session_id].add_message(AIMessage(content=conversation.message))
 
 def get_token_trimmer(model, max_tokens):
     return trim_messages(


### PR DESCRIPTION
1. chat_session_store에서 key값이 없는 경우에 대해 db에서 불러와서 init하지 않으므로 에러 발생

2. chat_session_store의 경우 dict 이므로 add_message 메소드 존재 x(key값을 통해 InMemoryChatMessageHistory 객체에 접근해야하는 문제 해결

3. chat_session_store에서 str으로 key값을 받던 것을 int로 받는 것으로 변경
> db에서 chat_session_id 받아올 때 int이므로 이에 대한 불필요한 후처리 제거

4. Pydantic model **generate_answer_request**의 변수 chat_session_id, question을 함수 초기에 선언하여 불필요한 코드 제거
> chat_session_id와 question은 해당 함수 내에서 자주 쓰이므로 generate_answer_request.chat_session_id와 같이 쓰기에는 코드가 너무 지저분해짐