### PR TITLE
[feat] pdf file 업로드 및 업로드된 pdf를 통한 rag

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 __pycache__/
 *.ipynb
 venv
+
 # Deep Learning Model Parameter
 *.gguf
 *.gguf
@@ -23,5 +24,5 @@ alembic.ini
 migrations
 *.db
 
-# document(test for rag)
-*.pdf
+# user upload files
+user-upload

--- a/definitions.py
+++ b/definitions.py
@@ -1,0 +1,3 @@
+import os
+
+ROOT_DIR = os.path.dirname(os.path.abspath(__file__))

--- a/domain/chat/chat_utils.py
+++ b/domain/chat/chat_utils.py
@@ -23,6 +23,7 @@ class InMemoryHistory(BaseChatMessageHistory, BaseModel):
         self.messages = []
 
 chat_session_store = {}
+retriever_store = {}
 
 def get_chat_session_history_from_dict(chat_session_id: int) -> BaseChatMessageHistory:
     if chat_session_id not in chat_session_store:


### PR DESCRIPTION
1. root 디렉토리 밑에 pdf 파일 저장하기 위해 definition.py 생성
2. user가 올린 pdf 파일에 대해 git ignore 적용
3. retriever store를 통해 계속해서 vector store를 생성할 필요 없이 caching


TODO

1. active chat session id가 -1일 때에 대한 처리 필요
2. user가 upload한 파일 db에 저장?