### PR TITLE
[fix] messages(bot, user) div 태그가 html 영역 밖으로 넘어가는 문제

### DIFF
--- a/frontend/src/routes/Home.svelte
+++ b/frontend/src/routes/Home.svelte
@@ -468,6 +468,7 @@
     overflow-y: auto;
     padding: 1rem;
     height: 100vh;
+    overflow-x: hidden;
   }
   .input-container {
     display: flex;
@@ -508,10 +509,13 @@
     padding: 0.75rem 1rem;
     border-radius: 10px;
     white-space: pre-wrap;
-    margin-right: 20vh;
-    margin-left: 20vh;
+    margin-right: 20%;
+    margin-left: 20%;
+    max-width: 60%;
     display: flex;
     justify-content: flex-start;
+    word-wrap: break-word;
+    word-break: break-word;
   }
   .message.user {
     text-align: right;
@@ -597,13 +601,16 @@
     background-color: #eee;
   }
   :global(.message-content p) {
-    margin: 0 0 0 0;
+    margin: 0;
   }
   :global(.message-content pre) {
     background-color: #eee;
     padding: 0.5rem;
     margin: 0;
     border-radius: 0.5rem;
+    white-space: pre-wrap;
+    word-wrap: break-word;
+    word-break: break-word;
   }
   :global(.message code) {
     font-family: 'Courier New', Courier, monospace;


### PR DESCRIPTION
### x축 스크롤, x축 너비 해결

- 문제 원인
    
    현재 messages 요소에서 X축 방향 스크롤이 생기는 문제는 자식 요소의 margin-right와 margin-left에 vh 단위를 사용했기 때문에 발생하는 것 같습니다.
    
- 해결
    1. (스크롤 해결) margin-left와 margin-right를 vh 대신 rem이나 % 단위로 수정: 화면의 높이에 비례하는 vh 단위를 사용하면 X축 스크롤이 생길 수 있으니, 대신 적절한 너비 단위를 사용합니다.
    2. (너비 해결) max-width 속성 추가: 자식 요소의 너비를 제한해 부모보다 커지지 않도록 합니다.

### 영역밖으로 글 넘침 -> 줄바꿈 해결

1. word-wrap과 word-break 속성 추가: 텍스트가 너무 길 때 자동으로 줄바꿈되도록 합니다.
2. pre 태그에서 줄바꿈 허용: pre 태그의 기본 속성인 white-space: pre-wrap을 적용하여 자동 줄바꿈을 허용합니다.