### PR TITLE
[refactor] swagger 동작을 위해 login inDTO 변경(custom OAuth2 -> official OAuth2)

### DIFF
--- a/frontend/src/routes/Auth.svelte
+++ b/frontend/src/routes/Auth.svelte
@@ -12,7 +12,7 @@
       event.preventDefault()
       let url = "/api/user/login"
       let params = {
-          email: user_email,
+          username: user_email,
           password: user_password,
       }
       fastapi('login', url, params, 


### PR DESCRIPTION
custom으로 설정된 OAuth2 request form의 경우 swagger가 동작하지 않음

official OAuth2의 경우 username과 password로 받아와야 하므로 이에 대해 inDTO 변경

참고: [full-stack-fastapi-template: login_access_token 함수](https://github.com/fastapi/full-stack-fastapi-template/blob/master/backend/app/api/routes/login.py#L25)